### PR TITLE
Creado listener que actualiza los archivos de traduccion

### DIFF
--- a/Controller/SyncController.php
+++ b/Controller/SyncController.php
@@ -45,11 +45,6 @@ class SyncController extends Controller
 
         $filenameTemplate = $this->container->getParameter('manuel_translation.filename_template');
 
-        foreach ($this->container->getParameter('manuel_translation.locales') as $locale) {
-            $filename = sprintf($filenameTemplate, $locale);
-            $this->get('filesystem')->dumpFile($filename, time());
-        }
-
         return $this->render('@ManuelTranslation/Sync/resolve_conflicts.html.twig', array(
             'news' => $result->getNews(),
             'updates' => $result->getUpdated(),

--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -63,14 +63,6 @@ class TranslationController extends Controller
 
         if (count($this->get('validator')->validate($translation)) == 0) {
             $this->get('manuel_translation.translations_repository')->saveTranslation($translation);
-
-            $filesystem = new Filesystem();
-            $filenameTemplate = $this->container->getParameter('manuel_translation.filename_template');
-
-            foreach ($translation->getValues() as $locale => $value) {
-                $filename = sprintf($filenameTemplate, $locale);
-                $filesystem->dumpFile($filename, time());
-            }
         }
 
 

--- a/Doctrine/Listener/DumpFilesListener.php
+++ b/Doctrine/Listener/DumpFilesListener.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the Manuel Aguirre Project.
+ *
+ * (c) Manuel Aguirre <programador.manuel@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ManuelAguirre\Bundle\TranslationBundle\Doctrine\Listener;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use ManuelAguirre\Bundle\TranslationBundle\Entity\Translation;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author maguirre <maguirre@developerplace.com>
+ */
+class DumpFilesListener
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+    /**
+     * @var array
+     */
+    private $locales;
+
+    /**
+     * @var string
+     */
+    private $filenameTemplate;
+
+    /**
+     * @var bool
+     * @internal
+     */
+    private $translationChanged = false;
+
+    /**
+     * DumpFilesListener constructor.
+     *
+     * @param Filesystem $filesystem
+     * @param array $locales
+     * @param string $filenameTemplate
+     */
+    public function __construct(Filesystem $filesystem, array $locales, $filenameTemplate)
+    {
+        $this->filesystem = $filesystem;
+        $this->locales = $locales;
+        $this->filenameTemplate = $filenameTemplate;
+    }
+
+    public function postPersist(LifecycleEventArgs $event)
+    {
+        $this->onTranslationSaved($event);
+    }
+
+    public function postUpdate(LifecycleEventArgs $event)
+    {
+        $this->onTranslationSaved($event);
+    }
+
+    public function onTranslationSaved(LifecycleEventArgs $event)
+    {
+        if ($event->getEntity() instanceof Translation) {
+            $this->translationChanged = true;
+        }
+    }
+
+    public function postFlush()
+    {
+        if ($this->translationChanged) {
+            foreach ($this->locales as $locale) {
+                $filename = sprintf($this->filenameTemplate, $locale);
+                $this->filesystem->dumpFile($filename, time());
+            }
+            
+            $this->translationChanged = false;
+        }
+    }
+}

--- a/Resources/config/services_dev.yml
+++ b/Resources/config/services_dev.yml
@@ -33,6 +33,17 @@ services:
             - { name: doctrine.event_listener, event: preUpdate }
             - { name: doctrine.event_listener, event: postFlush }
 
+    manuel_translation.doctrine.dump_files_listener:
+        class: ManuelAguirre\Bundle\TranslationBundle\Doctrine\Listener\DumpFilesListener
+        arguments:
+            - "@filesystem"
+            - "%manuel_translation.locales%"
+            - "%manuel_translation.filename_template%"
+        tags:
+            - { name: doctrine.event_listener, event: postUpdate }
+            - { name: doctrine.event_listener, event: postPersist }
+            - { name: doctrine.event_listener, event: postFlush }
+
     manuel_translation.translation_manager:
         class: ManuelAguirre\Bundle\TranslationBundle\Translation\TranslationManager
         arguments:


### PR DESCRIPTION
Este listener verifica si hubo algun cambio en la tabla de traducciones
para entonces proceder a actualizar los archivos de traduccion
necesarios por symfony para regenerar la caché en desarrollo.