### PR TITLE
Ahora se puede indicar el path de los catalogos

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('backup_dir')->defaultValue('%kernel.root_dir%/Resources/translations/backup/')->end()
                 ->scalarNode('filename_sync')->defaultValue('%kernel.root_dir%/Resources/translations/translations.txt')->end()
+                ->scalarNode('catalogues_path')->defaultValue('%kernel.root_dir%/Resources/translations/')->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/ManuelTranslationExtension.php
+++ b/DependencyInjection/ManuelTranslationExtension.php
@@ -34,8 +34,10 @@ class ManuelTranslationExtension extends Extension
         }
 
         $container->setParameter('manuel_translation.locales', $config['locales']);
-        $container->setParameter('manuel_translation.filename_template',
-            $container->getParameter('kernel.root_dir') . '/Resources/translations/messages.%s.doctrine');
+        $container->setParameter(
+            'manuel_translation.filename_template',
+            rtrim($config['catalogues_path'], '/') .'/messages.%s.doctrine'
+        );
         $container->setParameter('manuel_translation.translations_backup_dir', $config['backup_dir']);
         $container->setParameter('manuel_translation.filename_sync', $config['filename_sync']);
 


### PR DESCRIPTION
Con esto podemos especificar una ruta distinta en los servidores
de dev y prod para cuando se hace un despliegue automático.